### PR TITLE
Adress `categorize` feedback from Brayden

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: laundRy
 Title: laundRy - preprocessing package for dataframes
 Version: 0.1
-Authors@R: person("Arun", "Marria", email = "arun.marria@gmail.com",
-                  role = c("aut", "cre"))
+Authors@R: c(person("Arun", "Marria", email = "arun.marria@gmail.com",
+                  role = c("aut")),
            person("Cari", "Gostic", email = "cari.gostic@gmail.com",
-                  role = c("aut", "cre"))
+                  role = c("aut", "cre")),
            person("Alexander", "Hinton", email = "alexander_hinton@ubc.alumni.ca",
-                  role = c("aut", "cre"))
+                  role = c("aut")),
            person("Aman", "Garg", email = "gargkaman7@gmail.com",
-                  role = c("aut", "cre"))
+                  role = c("aut")))
 Description: The laundRy package performs many standard preprocessing techniques 
     for dataframes, before use in statistical analysis and machine learning. 
     The package functionality includes categorizing column types, handling 

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -9,17 +9,20 @@
 #' @param max_cat int, the maximum number of unique values that
 #' define a categorical column
 #'
-#' @return list with sub vectors named 'numeric' and 'categorical',
+#' @return list with char vectors named 'numeric' and 'categorical',
 #' containing column names of each type
 #' @export
 #' @examples
-#' categorize(data.frame(a = c(1.2,2.3,3.4), b = c('a','b','c')))
+#' categorize(data.frame(a = c(1.2, 2.3, 3.4), b = c('a', 'b', 'c')))
 
 categorize <- function(df, max_cat = 10) {
   # Check that inputs are valid
-  if(class(max_cat) != 'numeric') stop("Error: max_cat must be a positive integer")
-  if(max_cat%%1 != 0 | max_cat < 1) stop("Error: max_cat must be a positive integer")
-  if(class(df) != 'data.frame') stop("Error: Input for df must be of class data.frame")
+  (if(class(max_cat) != 'numeric')
+    stop("Error: max_cat must be a positive integer"))
+  (if(max_cat%%1 != 0 | max_cat < 1)
+    stop("Error: max_cat must be a positive integer"))
+  (if(class(df) != 'data.frame')
+    stop("Error: Input for df must be of class data.frame"))
 
 
   # Track all columns and their types
@@ -30,11 +33,13 @@ categorize <- function(df, max_cat = 10) {
   categorical <- c(names(col_types[col_types == 'factor']))
   # Add columns to list with fewer than or equal to max_cat unique values
   unique_vals <- sapply(df, function(x) length(unique(x)))
-  categorical <- append(categorical, names(unique_vals[unique_vals <= max_cat]))
+  categorical <- (append(categorical,
+                         names(unique_vals[unique_vals <= max_cat])))
 
   # Mark numeric columns
   # All columns of type numeric that aren't already marked categorical
-  numeric <- names(col_types[col_types == 'numeric' & !(names(col_types) %in% categorical)])
+  numeric <- (names(col_types[col_types == 'numeric' &
+                                !(names(col_types) %in% categorical)]))
 
   # Return list of vectors with duplicates removed
   return(list(numeric=unique(numeric), categorical=unique(categorical)))

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -5,9 +5,9 @@
 #' 'categorical' and 'text' containing column names
 #' that fall into each category
 #'
-#' @param df data.frame, a dataset
-#' @param max_cat int, maximum number of unique values that
-#' defines a categorical column
+#' @param df a data.frame
+#' @param max_cat int, the maximum number of unique values that
+#' define a categorical column
 #'
 #' @return list with sub vectors named 'numeric' and 'categorical',
 #' containing column names of each type

--- a/docs/reference/categorize.html
+++ b/docs/reference/categorize.html
@@ -139,17 +139,17 @@ that fall into each category</p>
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>df</th>
-      <td><p>data.frame</p></td>
+      <td><p>a data.frame</p></td>
     </tr>
     <tr>
       <th>max_cat</th>
-      <td><p>int</p></td>
+      <td><p>int, the maximum number of unique values that define a categorical column</p></td>
     </tr>
     </table>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>list</p>
+    <p>list with sub vectors named 'numeric' and 'categorical', containing column names of each type</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='fu'>categorize</span>(<span class='fu'><a href='https://rdrr.io/r/base/data.frame.html'>data.frame</a></span>(<span class='kw'>a</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='fl'>1.2</span>,<span class='fl'>2.3</span>,<span class='fl'>3.4</span>), <span class='kw'>b</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>'a'</span>,<span class='st'>'b'</span>,<span class='st'>'c'</span>)))</div><div class='output co'>#&gt; $numeric

--- a/man/categorize.Rd
+++ b/man/categorize.Rd
@@ -7,10 +7,10 @@
 categorize(df, max_cat = 10)
 }
 \arguments{
-\item{df}{data.frame, a dataset}
+\item{df}{a data.frame}
 
-\item{max_cat}{int, maximum number of unique values that
-defines a categorical column}
+\item{max_cat}{int, the maximum number of unique values that
+define a categorical column}
 }
 \value{
 list with sub vectors named 'numeric' and 'categorical',

--- a/man/categorize.Rd
+++ b/man/categorize.Rd
@@ -13,7 +13,7 @@ categorize(df, max_cat = 10)
 define a categorical column}
 }
 \value{
-list with sub vectors named 'numeric' and 'categorical',
+list with char vectors named 'numeric' and 'categorical',
 containing column names of each type
 }
 \description{
@@ -23,5 +23,5 @@ and return a list of lists labeled 'numeric',
 that fall into each category
 }
 \examples{
-categorize(data.frame(a = c(1.2,2.3,3.4), b = c('a','b','c')))
+categorize(data.frame(a = c(1.2, 2.3, 3.4), b = c('a', 'b', 'c')))
 }

--- a/tests/testthat/test_categorize.R
+++ b/tests/testthat/test_categorize.R
@@ -13,7 +13,8 @@ input <- data.frame(cat1 = c(1,2,3,1,4,3,3,2,1,1,
                     num2 = floor(runif(30, min = -10, max = 10)),
                     text1 = sprintf("text value %s", seq(1:30)),
                     num3 = runif(30, min = -100, max = 100),
-                    cat3 = rep(c("Mon", "Tue", "Wed", "Thu", "Fri"), times = 6),
+                    cat3 = rep(c("Mon", "Tue", "Wed", "Thu", "Fri"),
+                               times = 6),
                     text2 = sprintf("text instance #[%s]", seq(1:30)),
                     stringsAsFactors = FALSE
                     )
@@ -30,7 +31,8 @@ input_vec <- data.frame(cat1 = c(1,2,3,1,4,3,3,2,1,1,
                         num2 = floor(runif(30, min = -10, max = 10)),
                         text1 = sprintf("text value %s", seq(1:30)),
                         num3 = runif(30, min = -100, max = 100),
-                        cat3 = rep(c("Mon", "Tue", "Wed", "Thu", "Fri"), times = 6),
+                        cat3 = rep(c("Mon", "Tue", "Wed", "Thu", "Fri"),
+                                   times = 6),
                         text2 = sprintf("text instance #[%s]", seq(1:30)),
                         stringsAsFactors = TRUE
                         )
@@ -63,8 +65,16 @@ test_that("Output of numerical list is correct", {
 
 test_that("All factors should be classified as categorical", {
   output <- categorize(input_vec)
-  expect_true(all(c(output$categorical %in% list('cat1', 'cat2', 'cat3', 'text1', 'text2'),
-                    list('cat1', 'cat2', 'cat3', 'text1', 'text2') %in% output$categorical)))
+  expect_true(all(c(output$categorical %in% list('cat1',
+                                                 'cat2',
+                                                 'cat3',
+                                                 'text1',
+                                                 'text2'),
+                    list('cat1',
+                         'cat2',
+                         'cat3',
+                         'text1',
+                         'text2') %in% output$categorical)))
 })
 
 test_that("max_cat influences categorization", {
@@ -76,16 +86,23 @@ test_that("max_cat influences categorization", {
 })
 
 test_that("Invalid inputs throw errors", {
-  expect_error(categorize('hello!'), "Error: Input for df must be of class data.frame")
-  expect_error(categorize(c(1,2,3,2,1,2,3)), "Error: Input for df must be of class data.frame")
-  expect_error(categorize(input, -10), "Error: max_cat must be a positive integer")
-  expect_error(categorize(input, 1.3), "Error: max_cat must be a positive integer")
+  expect_error(categorize('hello!'),
+               "Error: Input for df must be of class data.frame")
+  expect_error(categorize(c(1,2,3,2,1,2,3)),
+               "Error: Input for df must be of class data.frame")
+  expect_error(categorize(input, -10),
+               "Error: max_cat must be a positive integer")
+  expect_error(categorize(input, 1.3),
+               "Error: max_cat must be a positive integer")
 })
 
-test_that("Empty list should be returned for empty input or inapplicable input", {
+test_that("Empty list should return for empty / inapplicable input",
+          {
   output_empty <- categorize(input_empty, max_cat = 2)
   output_none <- categorize(input_none, max_cat = 2)
-  expect_equal(output_empty, list(numeric=character(0), categorical=character(0)))
-  expect_equal(output_none, list(numeric=character(0), categorical=character(0)))
+  expect_equal(output_empty, list(numeric=character(0),
+                                  categorical=character(0)))
+  expect_equal(output_none, list(numeric=character(0),
+                                 categorical=character(0)))
 })
 

--- a/tests/testthat/test_feature_selection.R
+++ b/tests/testthat/test_feature_selection.R
@@ -20,8 +20,8 @@ test_1()
 
 test_2 <- function(){
   test_that("Test result for regression", {
-    X = generate_data_regression()[[1]]
-    y = generate_data_regression()[[2]]
+    X <- generate_data_regression()[[1]]
+    y <- generate_data_regression()[[2]]
 
     expect_true(feature_selection(X,y,"regression",1) == "x1")
 
@@ -34,8 +34,8 @@ test_2()
 
 test_3 <- function(){
   test_that("Test result for classification", {
-    X = generate_data_classification()[[1]]
-    y = generate_data_classification()[[2]]
+    X <- generate_data_classification()[[1]]
+    y <- generate_data_classification()[[2]]
     expect_true(feature_selection(X,y,"classification",1) == "x2")
 
   })
@@ -46,8 +46,8 @@ test_3()
 
 test_4 <- function(){
   test_that("Test result for Data Frame check", {
-    X = generate_data_wrong()[[1]]
-    y = generate_data_wrong()[[2]]
+    X <- generate_data_wrong()[[1]]
+    y <- generate_data_wrong()[[2]]
     expect_error(feature_selection(X,y,"classification",1) == "Input Data is not Data Frame")
 
   })
@@ -58,8 +58,8 @@ test_4()
 
 test_5 <- function(){
   test_that("Test result for Data Frame check", {
-    X = generate_data_wrong_one()[[1]]
-    y = generate_data_wrong_one()[[2]]
+    X <- generate_data_wrong_one()[[1]]
+    y <- generate_data_wrong_one()[[2]]
     expect_error(feature_selection(X,y,"classification",1) == "Input Data is not Data Frame")
 
   })


### PR DESCRIPTION
- FUNCTION: truncate long lines (80 char) in test and function
- DOCUMENTATION: Change the phrase "sub vectors" to just "character vectors".
    - I think this appears in categorize and fill_missing, maybe others?
- DOCUMENTATION: Comma + space between items in vectors in examples